### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,7 +5,7 @@ var util = require('../util'),
 	yeoman = require('yeoman-generator'),
 	chalk = require('chalk'),
     format = require('string-format'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     _ = require('lodash');
 
 var MeanGenerator = yeoman.generators.Base.extend({

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "ejs": "^2.3.3",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
-    "node-uuid": "latest",
     "string-format": "^0.5.0",
     "underscore.inflections": "~0.2.1",
+    "uuid": "^3.0.0",
     "yeoman-generator": "~0.20.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.